### PR TITLE
Wake Up FIX

### DIFF
--- a/src/SparkFunMLX90614.cpp
+++ b/src/SparkFunMLX90614.cpp
@@ -280,7 +280,8 @@ uint8_t IRTherm::sleep(void)
 
 uint8_t IRTherm::wake(void)
 {
-	// Wake operation from datasheet. (Doesn't seem to be working.)
+	// Wake operation from datasheet
+	Wire.end(); // stop i2c bus to send wake up request via digital pins
 	pinMode(SCL, INPUT); // SCL high
 	pinMode(SDA, OUTPUT);
 	digitalWrite(SDA, LOW); // SDA low


### PR DESCRIPTION
This fixes problem with wake up after sleep. You need to stop i2c bus BEFORE you send wake up request via digital pins - Wire.end() added to fix it.