### PR TITLE
replace deprecated digitalPinToPinName() with digitalPinToBitMask()

### DIFF
--- a/src/SparkFunMLX90614.h
+++ b/src/SparkFunMLX90614.h
@@ -24,10 +24,10 @@ SparkFun IR Thermometer Evaluation Board - MLX90614
 // Default I2C PIN for non Atmega Boards //
 ///////////////////////////////////////////
 #ifndef SDA
-#define SDA		(digitalPinToPinName(PIN_WIRE_SDA))
+#define SDA		(digitalPinToBitMask(PIN_WIRE_SDA))
 #endif
 #ifndef SCL
-#define SCL		(digitalPinToPinName(PIN_WIRE_SCL))
+#define SCL		(digitalPinToBitMask(PIN_WIRE_SCL))
 #endif
 
 //////////////////////////////////


### PR DESCRIPTION
digitalPinToPinName() has been deprecated in the Arduino core, causing this library to not compile anymore. digitalPinToBitMask() is more general and fixes the problem for this library.

Tested on an Arduino Uno with IDE 1.8.13

closes #2 